### PR TITLE
Cleanup and refactor #32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - os: macos-13
-            qt: "6.5.1"
+            qt: "6.5.2"
             variant: "qt6"
     name: CI macOS/install-qt (${{ matrix.os }}/${{ matrix.qt }})
     runs-on: ${{ matrix.os }}
@@ -143,7 +143,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            qt: "6.5.1"
+            qt: "6.5.2"
             variant: "current"
     name: CI Linux/AppImage (${{ matrix.os }}/${{ matrix.qt }})
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -154,13 +154,8 @@ fabric.properties
 .idea/caches/build_file_checksums.ser
 
 ### CLion+all Patch ###
-# Ignore everything but code style settings and run configurations
-# that are supposed to be shared within teams.
 
 .idea/*
-
-!.idea/codeStyles
-!.idea/runConfigurations
 
 ### Linux ###
 *~

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
       - id: fix-byte-order-marker
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
+    rev: v3.0.2
     hooks:
       - id: prettier
   - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/src/gui/widget/display_widget.h
+++ b/src/gui/widget/display_widget.h
@@ -110,8 +110,7 @@ class DisplayWidget : public QGraphicsView {
   QColor m_background_color, m_wall_color, m_floor_color;
   bool m_draw_floor{true}, m_draw_entities{true}, m_use_opengl{false},
       m_antialiasing{true}, m_restrict_floor{true}, m_restrict_path{true};
-  int m_simplify{1};
-  int m_wifi_id_filter{-1};
+  int m_simplify{1}, m_wifi_id_filter{-1};
   const Valeronoi::util::RGBColorMap *m_color_map{nullptr};
   Valeronoi::util::SegmentGenerator m_segment_generator;
 

--- a/src/robot/wifi_information.cpp
+++ b/src/robot/wifi_information.cpp
@@ -1,3 +1,20 @@
+/**
+ * Valeronoi is an app for generating WiFi signal strength maps
+ * Copyright (C) 2021-2023 Christian Friedrich Coors <me@ccoors.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "wifi_information.h"
 
 namespace Valeronoi::robot {

--- a/src/robot/wifi_information.cpp
+++ b/src/robot/wifi_information.cpp
@@ -33,7 +33,7 @@ class WifiInformationData : public QSharedData {
         m_bssid(other.m_bssid),
         m_signal(other.m_signal) {}
 
-  ~WifiInformationData() {}
+  ~WifiInformationData() = default;
 
   QString m_ssid;
   QString m_bssid;
@@ -59,8 +59,8 @@ WifiInformation::WifiInformation(const double signal)
   set_signal(signal);
 }
 
-WifiInformation::WifiInformation(const double signal, const QString ssid,
-                                 const QString bssid)
+WifiInformation::WifiInformation(double signal, const QString &ssid,
+                                 const QString &bssid)
     : m_data(new WifiInformationData) {
   set_signal(signal);
   set_ssid(ssid);
@@ -77,15 +77,13 @@ WifiInformation &WifiInformation::operator=(const WifiInformation &rhs) {
 
 WifiInformation::~WifiInformation() { m_data.reset(); }
 
-void WifiInformation::set_ssid(const QString ssid) { m_data->m_ssid = ssid; }
+void WifiInformation::set_ssid(const QString &ssid) { m_data->m_ssid = ssid; }
 
-void WifiInformation::set_bssid(const QString bssid) {
+void WifiInformation::set_bssid(const QString &bssid) {
   m_data->m_bssid = bssid;
 }
 
-void WifiInformation::set_signal(const double signal) {
-  m_data->m_signal = signal;
-}
+void WifiInformation::set_signal(double signal) { m_data->m_signal = signal; }
 
 QString WifiInformation::ssid() const { return m_data->m_ssid; }
 

--- a/src/robot/wifi_information.h
+++ b/src/robot/wifi_information.h
@@ -28,26 +28,26 @@ class WifiInformationData;
 class WifiInformation {
  public:
   WifiInformation();
-  WifiInformation(const QJsonObject &jsonObj);
-  WifiInformation(const double signal);
-  WifiInformation(const double signal, const QString ssid, const QString bssid);
+  explicit WifiInformation(const QJsonObject &jsonObj);
+  explicit WifiInformation(double signal);
+  WifiInformation(double signal, const QString &ssid, const QString &bssid);
 
   WifiInformation(const WifiInformation &);
   WifiInformation &operator=(const WifiInformation &);
   ~WifiInformation();
 
-  void set_ssid(const QString ssid);
-  void set_bssid(const QString bssid);
-  void set_signal(const double signal);
+  void set_ssid(const QString &ssid);
+  void set_bssid(const QString &bssid);
+  void set_signal(double signal);
 
-  QString ssid() const;
-  QString bssid() const;
-  double signal() const;
+  [[nodiscard]] QString ssid() const;
+  [[nodiscard]] QString bssid() const;
+  [[nodiscard]] double signal() const;
 
-  QJsonObject get_json() const;
+  [[nodiscard]] QJsonObject get_json() const;
   void set_json(QJsonObject jsonObj);
 
-  bool has_valid_signal() const;
+  [[nodiscard]] bool has_valid_signal() const;
 
  private:
   QSharedDataPointer<WifiInformationData> m_data;

--- a/src/robot/wifi_information.h
+++ b/src/robot/wifi_information.h
@@ -1,3 +1,20 @@
+/**
+ * Valeronoi is an app for generating WiFi signal strength maps
+ * Copyright (C) 2021-2023 Christian Friedrich Coors <me@ccoors.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef VALETUDO_ROBOT_WIFI_INFORMATION_H
 #define VALETUDO_ROBOT_WIFI_INFORMATION_H
 

--- a/src/state/measurements.cpp
+++ b/src/state/measurements.cpp
@@ -61,9 +61,9 @@ void Measurements::set_json(const QJsonArray &json) {
     const auto obj = v.toObject();
     int x = obj["x"].toInt();
     int y = obj["y"].toInt();
-    int wifiId = unkown_wifi_id;
+    int wifiId = unknown_wifi_id;
     if (obj.contains("wifi")) {
-      wifiId = obj["wifi"].toInt(unkown_wifi_id);
+      wifiId = obj["wifi"].toInt(unknown_wifi_id);
     }
     for (auto m : obj["data"].toArray()) {
       add_measurement(x, y, m.toDouble(), wifiId);

--- a/src/state/measurements.h
+++ b/src/state/measurements.h
@@ -45,7 +45,7 @@ class Measurements : public QObject {
 
   [[nodiscard]] MeasurementStatistics get_statistics() const;
 
-  int unkown_wifi_id = 0;
+  int unknown_wifi_id = 0;
 
  signals:
   void signal_measurements_updated();

--- a/src/state/wifi_collection.cpp
+++ b/src/state/wifi_collection.cpp
@@ -30,7 +30,7 @@ void wifi_collection::clear() {
 }
 
 int wifi_collection::get_or_create_wifi_id(
-    Valeronoi::robot::WifiInformation wifi_info) {
+    const Valeronoi::robot::WifiInformation& wifi_info) {
   int nRet = get_wifi_id(wifi_info.bssid());
 
   if (nRet < 0) {
@@ -40,13 +40,14 @@ int wifi_collection::get_or_create_wifi_id(
   return nRet;
 }
 
-int wifi_collection::add_wifi(Valeronoi::robot::WifiInformation wifi_info) {
+int wifi_collection::add_wifi(
+    const Valeronoi::robot::WifiInformation& wifi_info) {
   m_known_wifis.append(wifi_info);
   m_known_wifi_ids.append(m_known_wifis.size() - 1);
 
   if (m_known_wifis.size() != m_known_wifi_ids.size()) {
     // out of sync.
-    throw "Vector size missmatch! the data has get currupted somehow.";
+    throw std::runtime_error("Vector size mismatch! The data got corrupted.");
   }
 
   emit signal_wifi_list_updated();
@@ -65,14 +66,14 @@ QJsonArray wifi_collection::get_json() const {
 
   for (int index = 0; m_known_wifis.size() > index; ++index) {
     QJsonObject wifi_access_point = m_known_wifis.at(index).get_json();
-    wifi_access_point.insert("wifiId", m_known_wifi_ids.at(index));
+    wifi_access_point.insert("wifi_id", m_known_wifi_ids.at(index));
     jArr.append(wifi_access_point);
   }
 
   return jArr;
 }
 
-void wifi_collection::set_json(const QJsonArray &json) {
+void wifi_collection::set_json(const QJsonArray& json) {
   clear();
 
   foreach (auto wifi_access_point_value, json) {
@@ -81,11 +82,12 @@ void wifi_collection::set_json(const QJsonArray &json) {
       return;
     }
     QJsonObject wifi_access_point = wifi_access_point_value.toObject();
-    int wifi_id = wifi_access_point["wifiId"].toInt(-1);
+    int wifi_id = wifi_access_point["wifi_id"].toInt(-1);
     if (wifi_id < 0) {
       // Error parsing wifi_id.
       // This should not happen and there is no good way to handle this.
-      throw "sorry your Data seems to be currupted. The \"wifiId\" for your saved WiFis could not be parsed.";
+      throw std::runtime_error(
+          "The \"wifi_id\" for the saved WiFis could not be parsed.");
 
       // creating new WiFi Ids or remapping here would leave unmapped(lost)
       // measurement Data.
@@ -95,21 +97,16 @@ void wifi_collection::set_json(const QJsonArray &json) {
   }
 
   emit signal_wifi_list_updated();
-
-  return;
 }
 
-int wifi_collection::get_wifi_id(QString bssid) const {
-  int nRet = -1;
-
+int wifi_collection::get_wifi_id(const QString& bssid) const {
   for (int index = 0; m_known_wifis.size() > index; ++index) {
     if (m_known_wifis.at(index).bssid() == bssid) {
-      nRet = m_known_wifi_ids.at(index);
-      break;
+      return m_known_wifi_ids.at(index);
     }
   }
 
-  return nRet;
+  return -1;
 }
 
 }  // namespace Valeronoi::state

--- a/src/state/wifi_collection.cpp
+++ b/src/state/wifi_collection.cpp
@@ -65,7 +65,7 @@ QJsonArray wifi_collection::get_json() const {
 void wifi_collection::set_json(const QJsonArray& json) {
   clear();
 
-  foreach (auto wifi_access_point_value, json) {
+  for (const auto& wifi_access_point_value : json) {
     if (!wifi_access_point_value.isObject()) {
       // Wrong format.
       return;

--- a/src/state/wifi_collection.cpp
+++ b/src/state/wifi_collection.cpp
@@ -1,3 +1,21 @@
+/**
+ * Valeronoi is an app for generating WiFi signal strength maps
+ * Copyright (C) 2021-2023 Christian Friedrich Coors <me@ccoors.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "wifi_collection.h"
 
 #include "qjsonarray.h"

--- a/src/state/wifi_collection.h
+++ b/src/state/wifi_collection.h
@@ -1,3 +1,20 @@
+/**
+ * Valeronoi is an app for generating WiFi signal strength maps
+ * Copyright (C) 2021-2023 Christian Friedrich Coors <me@ccoors.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef VALERONOI_STATE_WIFI_COLLECTION_H
 #define VALERONOI_STATE_WIFI_COLLECTION_H
 

--- a/src/state/wifi_collection.h
+++ b/src/state/wifi_collection.h
@@ -51,10 +51,8 @@ class wifi_collection : public QObject {
 
   void signal_new_wifi_added(Valeronoi::robot::WifiInformation wifi_info);
 
- protected:
  private:
   QVector<Valeronoi::robot::WifiInformation> m_known_wifis;
-  QVector<int> m_known_wifi_ids;
 };
 
 }  // namespace Valeronoi::state

--- a/src/state/wifi_collection.h
+++ b/src/state/wifi_collection.h
@@ -33,19 +33,22 @@ class wifi_collection : public QObject {
 
   void clear();
 
-  int get_or_create_wifi_id(Valeronoi::robot::WifiInformation wifi_info);
+  int get_or_create_wifi_id(const Valeronoi::robot::WifiInformation& wifi_info);
 
-  int get_wifi_id(QString bssid) const;
+  [[nodiscard]] int get_wifi_id(const QString& bssid) const;
 
-  int add_wifi(Valeronoi::robot::WifiInformation wifi_info);
+  int add_wifi(const Valeronoi::robot::WifiInformation& wifi_info);
 
-  QVector<Valeronoi::robot::WifiInformation> get_known_wifis() const;
+  [[nodiscard]] QVector<Valeronoi::robot::WifiInformation> get_known_wifis()
+      const;
 
-  QJsonArray get_json() const;
-  void set_json(const QJsonArray &json);
+  [[nodiscard]] QJsonArray get_json() const;
+
+  void set_json(const QJsonArray& json);
 
  signals:
   void signal_wifi_list_updated();
+
   void signal_new_wifi_added(Valeronoi::robot::WifiInformation wifi_info);
 
  protected:

--- a/src/util/segment_generator.cpp
+++ b/src/util/segment_generator.cpp
@@ -86,7 +86,7 @@ void SegmentGenerator::run() {
         bool saveValue = true;
 
         if (wifi_id_filter != -1 && m.wifi_id != wifi_id_filter) {
-          continue;  // skip and probe next one
+          continue;  // Skip and probe next one
         }
 
         if (simplify > 1) {

--- a/src/valeronoi.cpp
+++ b/src/valeronoi.cpp
@@ -345,17 +345,22 @@ bool ValeronoiWindow::load_file(const QString &path) {
     QMessageBox::warning(nullptr, "Error", tr("File is corrupted"));
     return false;
   }
-  m_robot_map.update_map_json(json_document.object()["map"].toObject());
 
   if (json_document.object().contains("wifis")) {
-    m_wifi_collection.set_json(json_document.object()["wifis"].toArray());
+    try {
+      m_wifi_collection.set_json(json_document.object()["wifis"].toArray());
+    } catch (const std::runtime_error &e) {
+      QMessageBox::warning(nullptr, "Error", e.what());
+      return false;
+    }
   } else {
-    // add dummy wifi for Import.
+    // add dummy WiFi for Import.
     m_wifi_collection.clear();
-    m_wifi_measurements.unkown_wifi_id =
+    m_wifi_measurements.unknown_wifi_id =
         m_wifi_collection.get_or_create_wifi_id(
             Valeronoi::robot::WifiInformation());
   }
+  m_robot_map.update_map_json(json_document.object()["map"].toObject());
 
   m_wifi_measurements.set_json(
       json_document.object()["measurements"].toArray());

--- a/src/valeronoi.cpp
+++ b/src/valeronoi.cpp
@@ -144,6 +144,7 @@ void ValeronoiWindow::newFile() {
     m_wifi_measurements.reset();
     m_wifi_collection.clear();
     ui->wifiInfoGroup->setChecked(false);
+    ui->wifiList->clear();
     set_modified(false);
     update_title();
   }

--- a/src/valeronoi.cpp
+++ b/src/valeronoi.cpp
@@ -350,12 +350,7 @@ bool ValeronoiWindow::load_file(const QString &path) {
 
   ui->wifiInfoGroup->setChecked(false);
   if (json_document.object().contains("wifis")) {
-    try {
-      m_wifi_collection.set_json(json_document.object()["wifis"].toArray());
-    } catch (const std::runtime_error &e) {
-      QMessageBox::warning(nullptr, "Error", e.what());
-      return false;
-    }
+    m_wifi_collection.set_json(json_document.object()["wifis"].toArray());
   } else {
     // add dummy WiFi for Import.
     m_wifi_collection.clear();

--- a/src/valeronoi.h
+++ b/src/valeronoi.h
@@ -102,6 +102,8 @@ class ValeronoiWindow : public QMainWindow {
 
   void connect_actions();
 
+  void set_selected_wifi_item(const QListWidgetItem *widget_item);
+
   Ui::ValeronoiWindow *ui;
   Valeronoi::gui::widget::DisplayWidget *m_display_widget;
 

--- a/src/valeronoi.ui
+++ b/src/valeronoi.ui
@@ -149,41 +149,6 @@
              </spacer>
             </item>
             <item>
-             <widget class="QGroupBox" name="wifiInfoGroup">
-              <property name="title">
-               <string>WiFi AccessPoints</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_9">
-               <item>
-                <widget class="QListWidget" name="wifiList">
-                 <property name="sizeAdjustPolicy">
-                  <enum>QAbstractScrollArea::AdjustToContents</enum>
-                 </property>
-                 <property name="selectionBehavior">
-                  <enum>QAbstractItemView::SelectRows</enum>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>10</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
              <widget class="QGroupBox" name="recordingStatsGroup">
               <property name="title">
                <string>Recording statistics</string>
@@ -511,6 +476,31 @@
              </layout>
             </item>
             <item>
+             <widget class="QGroupBox" name="wifiInfoGroup">
+              <property name="title">
+               <string>Filter WiFi AccessPoints</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_9">
+               <item>
+                <widget class="QListWidget" name="wifiList">
+                 <property name="sizeAdjustPolicy">
+                  <enum>QAbstractScrollArea::AdjustToContents</enum>
+                 </property>
+                 <property name="selectionBehavior">
+                  <enum>QAbstractItemView::SelectRows</enum>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="displayRestrictFloor">
               <property name="statusTip">
                <string>Draw data only on the floor</string>
@@ -668,7 +658,7 @@
      <x>0</x>
      <y>0</y>
      <width>920</width>
-     <height>22</height>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">


### PR DESCRIPTION
Cleanup and refactor #32 as well as some other minor changes

- Added copyright headers
- Updated to Qt 6.5.2
- Updated pre-commit hooks/optimized .gitignore
- Removed exceptions
- Encoded the WiFi BSSID in the `QListWidgetItem` data instead of parsing it back using a RegEx (ew)
- Removed `m_known_wifi_ids` as it contains redundant data (since the list is never sorted anyway)