### PR TITLE
headless recorder - Add headless CLI mode for automated WiFi recording

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(CMAKE_AUTOUIC ON)
 
 set(SOURCE_FILES
     src/main.cpp
+    src/cli/headless_recorder.cpp
     src/valeronoi.ui
     src/valeronoi.qrc
     src/valeronoi.cpp

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -1,0 +1,11 @@
+#
+# podman build -f Containerfile.build -t valeronoi-build .
+#
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake qt6-base-dev libqt6svg6-dev libqt6opengl6-dev libcgal-dev libboost-dev libssl-dev libgl-dev libvulkan-dev libxkbcommon-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+#
+# podman run --rm -ti -v "$PWD:/host:Z" -w "/host" valeronoi-build bash -c "mkdir -p build && cd build && cmake .. && cmake --build -j ."
+#

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -4,6 +4,8 @@
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential cmake qt6-base-dev libqt6svg6-dev libqt6opengl6-dev libcgal-dev libboost-dev libssl-dev libgl-dev libvulkan-dev libxkbcommon-dev \
+    git python3 python3-pip clang-format shellcheck shfmt \
+  && pip3 install pre-commit \
   && rm -rf /var/lib/apt/lists/*
 
 #

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -7,5 +7,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 #
-# podman run --rm -ti -v "$PWD:/host:Z" -w "/host" valeronoi-build bash -c "mkdir -p build && cd build && cmake .. && cmake --build -j ."
+# podman run --rm -ti -v "$PWD:/host:Z" -w "/host" valeronoi-build bash -c "mkdir -p build && cd build && cmake .. && cmake --build . -j$(nproc)"
 #

--- a/Containerfile.run
+++ b/Containerfile.run
@@ -1,0 +1,17 @@
+#
+# podman build -f Containerfile.run -t valeronoi .
+#
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libqt6network6 libqt6svg6 libqt6openglwidgets6 \
+    libqt6widgets6 libqt6gui6 libqt6core6 \
+    qt6-qpa-plugins \
+    libgmp10 libssl3 libgl1 libxkbcommon0 \
+  && rm -rf /var/lib/apt/lists/*
+ENV QT_QPA_PLATFORM=offscreen
+COPY ./valeronoi /usr/local/bin/valeronoi
+ENTRYPOINT ["valeronoi"]
+
+#
+# podman run --rm --network host -v "$PWD/output:/output:Z" valeronoi --headless --output "/output/wifi_$(date +%F_%H%M).vwm" --url http://192.168.30.15 --interval 10 --duration 60 --mode vacuum --command start
+#

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Valeronoi (Valetudo + Voronoi) is a companion for [Valetudo](https://valetudo.cl
 - **Persistent Storage**: Save and load your measurements in the Valeronoi WiFi Map (`.vwm`) format.
 - **Robot Control**: Basic controls for starting/stopping cleanups directly from the app.
 - **Cross-platform**: Available for Linux, macOS, and Windows.
-- **Headless CLI Mode (on Linux)**: Automated recording without GUI, ideal for scheduled scans via cron or containers.
+- **Headless CLI Mode (tested on Linux)**: Automated recording without GUI, ideal for scheduled scans via cron or containers.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Valeronoi (Valetudo + Voronoi) is a companion for [Valetudo](https://valetudo.cl
 - **Persistent Storage**: Save and load your measurements in the Valeronoi WiFi Map (`.vwm`) format.
 - **Robot Control**: Basic controls for starting/stopping cleanups directly from the app.
 - **Cross-platform**: Available for Linux, macOS, and Windows.
+- **Headless CLI Mode (on Linux)**: Automated recording without GUI, ideal for scheduled scans via cron or containers.
 
 ## Installation
 
@@ -83,6 +84,69 @@ cmake ..
 cmake --build .
 ./valeronoi-tests
 ```
+
+### Headless CLI Mode
+
+Valeronoi can run without a GUI for automated WiFi scans, e.g. triggered by a cron job on a headless home server.
+
+#### Usage
+
+```bash
+# Start cleaning in vacuum-only mode and record for 30 minutes
+valeronoi --headless \
+  --url http://192.168.1.100 \
+  --mode vacuum \
+  --command start \
+  --output scan.vwm \
+  --duration 1800
+
+# Send a command without recording (e.g. send robot home)
+valeronoi --headless --url http://192.168.1.100 --command home
+```
+
+Pressing `Ctrl+C` (or sending `SIGTERM`) saves collected data before exiting.
+
+#### Options
+
+| Option              | Description                                               |
+| ------------------- | --------------------------------------------------------- |
+| `--headless`        | Run without GUI (required)                                |
+| `--url <url>`       | Valetudo robot URL                                        |
+| `--output <file>`   | Output `.vwm` file (extension added automatically)        |
+| `--duration <sec>`  | Stop recording after N seconds                            |
+| `--interval <sec>`  | WiFi polling interval (default: 5s)                       |
+| `--mode <mode>`     | Set operation mode: `vacuum`, `mop`, `vacuum_and_mop`     |
+| `--command <cmd>`   | Robot command: `start`, `stop`, `home`, `pause`, `locate` |
+| `--return-home`     | Send stop + home when recording ends (duration or Ctrl+C) |
+| `--auth`            | Enable HTTP basic auth                                    |
+| `--user` / `--pass` | Auth credentials                                          |
+
+Non-start commands (`stop`, `home`, `pause`, `locate`) execute immediately and exit — no recording is performed even if `--output` is specified.
+
+#### Container usage
+
+```bash
+# Build
+podman build -f Containerfile.build -t valeronoi-build .
+podman run --rm -v "$PWD:/host:Z" -w /host valeronoi-build \
+  bash -c "mkdir -p build && cd build && cmake .. && cmake --build . -j$(nproc)"
+podman build -f Containerfile.run -t valeronoi .
+
+# Run
+podman run --rm --network host -v ./output:/output:Z valeronoi \
+  --headless --url http://192.168.1.100 \
+  --mode vacuum --command start \
+  --output /output/wifi_$(date +%F_%H%M).vwm --duration 1800
+```
+
+#### Cron example
+
+```cron
+# Daily 30-minute WiFi scan at 10:00
+0 10 * * * podman run --rm --network host -v /data/wifi:/output:Z valeronoi --headless --url http://192.168.1.100 --mode vacuum --command start --output /output/scan_$(date +\%F).vwm --duration 1800
+```
+
+The resulting `.vwm` files can be opened in the GUI for Voronoi visualization and image export.
 
 ## Contributing
 

--- a/src/cli/headless_recorder.cpp
+++ b/src/cli/headless_recorder.cpp
@@ -1,0 +1,337 @@
+/**
+ * Valeronoi is an app for generating WiFi signal strength maps
+ * Copyright (C) 2021-2026 Christian Friedrich Coors <me@ccoors.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "headless_recorder.h"
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSettings>
+#include <QTextStream>
+#include <csignal>
+#include <cstdlib>
+
+// Global pointer for signal handler (graceful Ctrl+C)
+static Valeronoi::cli::HeadlessRecorder *g_recorder = nullptr;
+
+// NOTE: Not strictly async-signal-safe, but works reliably with Qt's event
+// loop
+static void signal_handler(int) {
+  if (g_recorder) {
+    QMetaObject::invokeMethod(g_recorder, "slot_duration_elapsed",
+                              Qt::QueuedConnection);
+  }
+}
+
+namespace Valeronoi::cli {
+
+HeadlessRecorder::HeadlessRecorder(QObject *parent) : QObject(parent) {
+  // Link measurements to robot map (provides robot position)
+  m_measurements.set_map(m_robot_map);
+
+  // Robot signals
+  connect(&m_robot, &robot::Robot::signal_connected, this,
+          &HeadlessRecorder::slot_connected);
+  connect(&m_robot, &robot::Robot::signal_connection_error, this,
+          &HeadlessRecorder::slot_connection_error);
+  connect(&m_robot, &robot::Robot::signal_map_updated, this,
+          &HeadlessRecorder::slot_map_updated);
+  connect(&m_robot, &robot::Robot::signal_wifi_info_updated, this,
+          &HeadlessRecorder::slot_wifi_info_updated);
+
+  // Duration timer (single shot)
+  m_duration_timer.setSingleShot(true);
+  connect(&m_duration_timer, &QTimer::timeout, this,
+          &HeadlessRecorder::slot_duration_elapsed);
+}
+
+void HeadlessRecorder::set_output(const QString &path) {
+  m_output_path = path;
+  // Append default file extension if none is present
+  if (!m_output_path.isEmpty() && QFileInfo(m_output_path).suffix().isEmpty()) {
+    m_output_path.append(".vwm");
+  }
+}
+
+void HeadlessRecorder::set_duration(int seconds) {
+  m_duration_seconds = seconds;
+}
+
+void HeadlessRecorder::set_interval(double seconds) {
+  m_interval_seconds = seconds;
+}
+
+void HeadlessRecorder::set_url(const QString &url) { m_url = url; }
+
+void HeadlessRecorder::set_auth(const QString &username,
+                                const QString &password) {
+  m_auth = true;
+  m_username = username;
+  m_password = password;
+}
+
+void HeadlessRecorder::set_command(const QString &command) {
+  m_command = command.toLower();
+}
+
+void HeadlessRecorder::set_operation_mode(const QString &mode) {
+  m_operation_mode = mode.toLower();
+}
+
+void HeadlessRecorder::set_return_home(bool enabled) {
+  m_return_home = enabled;
+}
+
+void HeadlessRecorder::load_file(const QString &path) { m_load_path = path; }
+
+int HeadlessRecorder::run() {
+  QTextStream out(stdout);
+
+  // If no output but a command is set, run in "command-only" mode
+  if (m_output_path.isEmpty() && m_command.isEmpty()) {
+    out << "Error: --output or --command is required in headless mode\n";
+    out.flush();
+    return 1;
+  }
+
+  // Load existing measurements if provided
+  if (!m_load_path.isEmpty()) {
+    QFile file(m_load_path);
+    if (file.open(QIODevice::ReadOnly)) {
+      auto doc = QJsonDocument::fromJson(file.readAll());
+      auto obj = doc.object();
+      if (obj.contains("measurements")) {
+        m_measurements.set_json(obj.value("measurements").toArray());
+      }
+      if (obj.contains("map")) {
+        m_robot_map.update_map_json(obj.value("map").toObject());
+      }
+      out << "Loaded existing data from " << m_load_path << "\n";
+      out.flush();
+    } else {
+      out << "Warning: Could not open " << m_load_path << "\n";
+      out.flush();
+    }
+  }
+
+  // Build connection configuration from CLI args or QSettings
+  robot::ConnectionConfiguration config;
+
+  if (!m_url.isEmpty()) {
+    // Use CLI parameters
+    config.m_url = QUrl(m_url);
+    config.m_auth = m_auth;
+    config.m_username = m_username;
+    config.m_password = m_password;
+  } else {
+    // Fall back to QSettings (configured via GUI)
+    config.read_settings();
+  }
+
+  if (!config.is_valid()) {
+    out << "Error: No valid robot connection configured.\n";
+    out << "Use --url to specify the robot URL, e.g.:\n";
+    out << "  valeronoi --headless --url http://robot:80 --output out.vwm\n";
+    out.flush();
+    return 1;
+  }
+
+  out << "Connecting to " << config.m_url.toString() << " ...\n";
+  out.flush();
+
+  m_robot.set_connection_configuration(config);
+  m_robot.slot_connect();
+
+  // Handle Ctrl+C / SIGTERM gracefully to save before exit
+  g_recorder = this;
+  std::signal(SIGINT, signal_handler);
+  std::signal(SIGTERM, signal_handler);
+
+  return QCoreApplication::exec();
+}
+
+void HeadlessRecorder::slot_connected() {
+  if (m_exiting) return;
+
+  QTextStream out(stdout);
+  out << "Connected.";
+
+  // Set operation mode before sending command
+  // (e.g. "vacuum" instead of "vacuum_and_mop")
+  if (!m_operation_mode.isEmpty()) {
+    out << " Setting mode: " << m_operation_mode << ".";
+    m_robot.set_operation_mode(m_operation_mode);
+  }
+
+  // Send robot command if specified
+  if (!m_command.isEmpty()) {
+    robot::BASIC_COMMANDS cmd;
+    bool valid_cmd = true;
+
+    if (m_command == "start" || m_command == "clean") {
+      cmd = robot::BASIC_COMMANDS::START;
+    } else if (m_command == "pause") {
+      cmd = robot::BASIC_COMMANDS::PAUSE;
+    } else if (m_command == "stop") {
+      cmd = robot::BASIC_COMMANDS::STOP;
+    } else if (m_command == "home" || m_command == "dock") {
+      cmd = robot::BASIC_COMMANDS::HOME;
+    } else if (m_command == "locate") {
+      cmd = robot::BASIC_COMMANDS::LOCATE;
+    } else {
+      out << "\nWarning: Unknown command '" << m_command
+          << "' (valid: start, pause, stop, home, locate)\n";
+      valid_cmd = false;
+    }
+
+    if (valid_cmd) {
+      out << " Sending command: " << m_command << ".";
+      m_robot.send_command(cmd);
+    }
+  }
+
+  // Command-only mode: no recording needed for non-start commands,
+  // or when no output is specified.
+  bool command_only =
+      m_output_path.isEmpty() ||
+      (!m_command.isEmpty() && m_command != "start" && m_command != "clean");
+
+  if (command_only) {
+    out << " Done.\n";
+    out.flush();
+    // Give the event loop time to actually send the HTTP requests
+    // 2s delay: enough for local HTTP requests to complete before exit
+    QTimer::singleShot(2000, this, [this]() {
+      m_robot.slot_disconnect();
+      fflush(stdout);
+      std::exit(0);
+    });
+    return;
+  }
+
+  out << " Starting recording";
+  if (m_duration_seconds > 0) {
+    out << " for " << m_duration_seconds << "s";
+    m_duration_timer.start(m_duration_seconds * 1000);
+  }
+  out << " (interval: " << m_interval_seconds << "s)\n";
+  out.flush();
+
+  // Start wifi polling with the configured interval
+  m_robot.slot_subscribe_wifi(m_interval_seconds);
+}
+
+void HeadlessRecorder::slot_connection_error() {
+  if (m_exiting) return;
+
+  QTextStream err(stderr);
+  err << "Connection error: " << m_robot.get_error() << "\n";
+  err.flush();
+  save_and_exit(1);
+}
+
+void HeadlessRecorder::slot_map_updated() {
+  if (m_exiting) return;
+
+  // Update local robot map from the robot's SSE map data
+  const QString map_data = m_robot.get_map_data();
+  if (!map_data.isEmpty()) {
+    m_robot_map.update_map_json(map_data);
+  }
+}
+
+void HeadlessRecorder::slot_wifi_info_updated(
+    Valeronoi::robot::WifiInformation wifi_info) {
+  if (m_exiting) return;
+
+  QTextStream out(stdout);
+
+  // Add measurement at current robot position
+  m_measurements.slot_add_measurement(wifi_info.signal(),
+                                      m_measurements.unknown_wifi_id);
+
+  out << "  Measurement recorded (total: "
+      << m_measurements.get_measurements().size() << ")\n";
+  out.flush();
+}
+
+void HeadlessRecorder::slot_duration_elapsed() {
+  if (m_exiting) return;
+  m_exiting = true;
+
+  QTextStream out(stdout);
+  out << "\nDuration elapsed.";
+  out.flush();
+
+  // Stop all timers
+  m_duration_timer.stop();
+  m_robot.slot_stop_wifi_subscription();
+
+  // Optionally stop cleaning and send robot home before saving
+  if (m_return_home) {
+    out << " Sending stop + home...\n";
+    out.flush();
+    m_robot.send_command(robot::BASIC_COMMANDS::STOP);
+    m_robot.send_command(robot::BASIC_COMMANDS::HOME);
+    // Give event loop time to send the HTTP requests
+    QTimer::singleShot(3000, this, [this]() {
+      QTextStream out(stdout);
+      out << "Saving...\n";
+      out.flush();
+      m_robot.slot_disconnect();
+      save_and_exit(0);
+    });
+  } else {
+    out << " Saving...\n";
+    out.flush();
+    m_robot.slot_disconnect();
+    save_and_exit(0);
+  }
+}
+
+void HeadlessRecorder::save_and_exit(int code) {
+  QTextStream out(stdout);
+
+  if (!m_output_path.isEmpty() && !m_measurements.get_measurements().empty()) {
+    QJsonObject root;
+    root["measurements"] = m_measurements.get_json();
+    root["map"] = m_robot_map.get_map_json();
+    root["version"] = 1;
+
+    QFile file(m_output_path);
+    if (file.open(QIODevice::WriteOnly)) {
+      file.write(QJsonDocument(root).toJson());
+      out << "Saved " << m_measurements.get_measurements().size()
+          << " measurements to " << m_output_path << "\n";
+    } else {
+      out << "Error: Could not write to " << m_output_path << "\n";
+      code = 1;
+    }
+  } else if (m_measurements.get_measurements().empty()) {
+    out << "No measurements recorded.\n";
+  }
+
+  out.flush();
+  fflush(stdout);
+  fflush(stderr);
+  std::exit(code);
+}
+
+}  // namespace Valeronoi::cli

--- a/src/cli/headless_recorder.cpp
+++ b/src/cli/headless_recorder.cpp
@@ -26,7 +26,6 @@
 #include <QSettings>
 #include <QTextStream>
 #include <csignal>
-#include <cstdlib>
 
 // Global pointer for signal handler (graceful Ctrl+C)
 static Valeronoi::cli::HeadlessRecorder *g_recorder = nullptr;
@@ -221,7 +220,7 @@ void HeadlessRecorder::slot_connected() {
     QTimer::singleShot(2000, this, [this]() {
       m_robot.slot_disconnect();
       fflush(stdout);
-      std::exit(0);
+      QCoreApplication::exit(0);
     });
     return;
   }
@@ -331,7 +330,7 @@ void HeadlessRecorder::save_and_exit(int code) {
   out.flush();
   fflush(stdout);
   fflush(stderr);
-  std::exit(code);
+  QCoreApplication::exit(code);
 }
 
 }  // namespace Valeronoi::cli

--- a/src/cli/headless_recorder.h
+++ b/src/cli/headless_recorder.h
@@ -47,10 +47,8 @@ class HeadlessRecorder : public QObject {
 
   int run();
 
- public slots:
-  void slot_duration_elapsed();
-
  private slots:
+  void slot_duration_elapsed();
   void slot_connected();
   void slot_connection_error();
   void slot_map_updated();

--- a/src/cli/headless_recorder.h
+++ b/src/cli/headless_recorder.h
@@ -1,0 +1,85 @@
+/**
+ * Valeronoi is an app for generating WiFi signal strength maps
+ * Copyright (C) 2021-2026 Christian Friedrich Coors <me@ccoors.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef VALERONOI_CLI_HEADLESS_RECORDER_H
+#define VALERONOI_CLI_HEADLESS_RECORDER_H
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+#include <QUrl>
+
+#include "../robot/robot.h"
+#include "../state/measurements.h"
+#include "../state/robot_map.h"
+
+namespace Valeronoi::cli {
+
+class HeadlessRecorder : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit HeadlessRecorder(QObject *parent = nullptr);
+
+  void set_output(const QString &path);
+  void set_duration(int seconds);
+  void set_interval(double seconds);
+  void set_url(const QString &url);
+  void set_auth(const QString &username, const QString &password);
+  void set_command(const QString &command);
+  void set_operation_mode(const QString &mode);
+  void set_return_home(bool enabled);
+  void load_file(const QString &path);
+
+  int run();
+
+ public slots:
+  void slot_duration_elapsed();
+
+ private slots:
+  void slot_connected();
+  void slot_connection_error();
+  void slot_map_updated();
+  void slot_wifi_info_updated(Valeronoi::robot::WifiInformation wifi_info);
+
+ private:
+  void save_and_exit(int code);
+
+  Valeronoi::robot::Robot m_robot;
+  Valeronoi::state::RobotMap m_robot_map;
+  Valeronoi::state::Measurements m_measurements;
+
+  QString m_output_path;
+  QString m_load_path;
+  QString m_url;
+  QString m_username;
+  QString m_password;
+  QString m_command;
+  QString m_operation_mode;
+  bool m_auth{false};
+  bool m_return_home{false};
+
+  int m_duration_seconds{0};
+  double m_interval_seconds{1.0};
+
+  QTimer m_duration_timer;
+  bool m_exiting{false};
+};
+
+}  // namespace Valeronoi::cli
+
+#endif  // VALERONOI_CLI_HEADLESS_RECORDER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,6 @@
 #include "valeronoi.h"
 
 int main(int argc, char** argv) {
-
   // Check for --headless before creating QApplication.
   // Forces offscreen QPA platform so no display is required.
   bool headless_mode = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,8 +120,34 @@ int main(int argc, char** argv) {
   if (parser.isSet(headlessOpt)) {
     Valeronoi::cli::HeadlessRecorder recorder;
     recorder.set_output(parser.value(outputOpt));
-    recorder.set_duration(parser.value(durationOpt).toInt());
-    recorder.set_interval(parser.value(intervalOpt).toDouble());
+
+    // Validate --duration: must be a positive integer (0 = unlimited)
+    if (parser.isSet(durationOpt)) {
+      bool ok = false;
+      const int duration = parser.value(durationOpt).toInt(&ok);
+      if (!ok || duration < 0) {
+        fprintf(stderr,
+                "Error: --duration must be a non-negative integer (seconds), "
+                "got '%s'\n",
+                qPrintable(parser.value(durationOpt)));
+        return 1;
+      }
+      recorder.set_duration(duration);
+    }
+
+    // Validate --interval: must be a positive number > 0
+    {
+      bool ok = false;
+      const double interval = parser.value(intervalOpt).toDouble(&ok);
+      if (!ok || interval <= 0.0) {
+        fprintf(stderr,
+                "Error: --interval must be a positive number (seconds), "
+                "got '%s'\n",
+                qPrintable(parser.value(intervalOpt)));
+        return 1;
+      }
+      recorder.set_interval(interval);
+    }
 
     if (parser.isSet(urlOpt)) {
       recorder.set_url(parser.value(urlOpt));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,8 +103,6 @@ int main(int argc, char** argv) {
       "Send stop + home commands when duration elapsed or Ctrl+C is pressed");
 
   parser.addOption(headlessOpt);
-
-  parser.addOption(headlessOpt);
   parser.addOption(outputOpt);
   parser.addOption(durationOpt);
   parser.addOption(intervalOpt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,6 @@
 #include "valeronoi.h"
 
 int main(int argc, char** argv) {
-  qInstallMessageHandler(Valeronoi::util::log_handler);
 
   // Check for --headless before creating QApplication.
   // Forces offscreen QPA platform so no display is required.
@@ -43,6 +42,10 @@ int main(int argc, char** argv) {
   // If not headless, check if a display is available.
   // Prevents "Aborted (core dumped)" in containers or SSH sessions.
   if (!headless_mode) {
+    // Redirect Qt log messages to the in-app LogDialog (GUI only).
+    // In headless mode, messages go to stderr via Qt's default handler.
+    qInstallMessageHandler(Valeronoi::util::log_handler);
+
     const bool has_display = !qEnvironmentVariableIsEmpty("DISPLAY") ||
                              !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY") ||
                              !qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include <QMetaType>
 #include <QtWidgets>
 
+#include "cli/headless_recorder.h"
 #include "config.h"
 #include "state/state.h"
 #include "util/log_helper.h"
@@ -27,6 +28,35 @@
 
 int main(int argc, char** argv) {
   qInstallMessageHandler(Valeronoi::util::log_handler);
+
+  // Check for --headless before creating QApplication.
+  // Forces offscreen QPA platform so no display is required.
+  bool headless_mode = false;
+  for (int i = 1; i < argc; ++i) {
+    if (QString(argv[i]) == "--headless") {
+      headless_mode = true;
+      qputenv("QT_QPA_PLATFORM", "offscreen");
+      break;
+    }
+  }
+
+  // If not headless, check if a display is available.
+  // Prevents "Aborted (core dumped)" in containers or SSH sessions.
+  if (!headless_mode) {
+    const bool has_display = !qEnvironmentVariableIsEmpty("DISPLAY") ||
+                             !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY") ||
+                             !qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM");
+
+    if (!has_display) {
+      fprintf(stderr,
+              "Error: No display available.\n"
+              "Run with --headless for CLI mode, e.g.:\n"
+              "  valeronoi --headless --url http://robot:80 "
+              "--output out.vwm --duration 60\n"
+              "\nOr set QT_QPA_PLATFORM=offscreen to suppress this.\n");
+      return 1;
+    }
+  }
 
   QApplication app(argc, argv);
   QCoreApplication::setOrganizationName("ccoors");
@@ -46,8 +76,78 @@ int main(int argc, char** argv) {
   parser.addHelpOption();
   parser.addVersionOption();
   parser.addPositionalArgument("file", "The file to open.");
+
+  // Headless CLI options
+  QCommandLineOption headlessOpt("headless", "Run without GUI (record mode)");
+  QCommandLineOption outputOpt("output", "Output file path (e.g., 'run1.vwm')",
+                               "file");
+  QCommandLineOption durationOpt("duration", "Recording duration in seconds",
+                                 "seconds");
+  QCommandLineOption intervalOpt("interval", "Polling interval in seconds",
+                                 "seconds", "5.0");
+  QCommandLineOption urlOpt("url", "Robot Valetudo URL (e.g. http://robot:80)",
+                            "url");
+  QCommandLineOption authOpt("auth", "Enable HTTP basic auth");
+  QCommandLineOption userOpt("user", "HTTP auth username", "username");
+  QCommandLineOption passOpt("pass", "HTTP auth password", "password");
+  QCommandLineOption commandOpt(
+      "command",
+      "Send robot command on connect (start, pause, stop, home, locate). "
+      "Without --output, sends command and exits immediately.",
+      "cmd");
+  QCommandLineOption modeOpt(
+      "mode", "Set operation mode before start (vacuum, mop, vacuum_and_mop)",
+      "mode");
+  QCommandLineOption returnHomeOpt(
+      "return-home",
+      "Send stop + home commands when duration elapsed or Ctrl+C is pressed");
+
+  parser.addOption(headlessOpt);
+
+  parser.addOption(headlessOpt);
+  parser.addOption(outputOpt);
+  parser.addOption(durationOpt);
+  parser.addOption(intervalOpt);
+  parser.addOption(urlOpt);
+  parser.addOption(authOpt);
+  parser.addOption(userOpt);
+  parser.addOption(passOpt);
+  parser.addOption(commandOpt);
+  parser.addOption(modeOpt);
+  parser.addOption(returnHomeOpt);
+
   parser.process(app);
 
+  // ---- Headless CLI mode ----
+  if (parser.isSet(headlessOpt)) {
+    Valeronoi::cli::HeadlessRecorder recorder;
+    recorder.set_output(parser.value(outputOpt));
+    recorder.set_duration(parser.value(durationOpt).toInt());
+    recorder.set_interval(parser.value(intervalOpt).toDouble());
+
+    if (parser.isSet(urlOpt)) {
+      recorder.set_url(parser.value(urlOpt));
+    }
+    if (parser.isSet(authOpt)) {
+      recorder.set_auth(parser.value(userOpt), parser.value(passOpt));
+    }
+    if (parser.isSet(modeOpt)) {
+      recorder.set_operation_mode(parser.value(modeOpt));
+    }
+    if (parser.isSet(commandOpt)) {
+      recorder.set_command(parser.value(commandOpt));
+    }
+    if (parser.isSet(returnHomeOpt)) {
+      recorder.set_return_home(true);
+    }
+    if (!parser.positionalArguments().isEmpty()) {
+      recorder.load_file(parser.positionalArguments().value(0));
+    }
+
+    return recorder.run();
+  }
+
+  // ---- Normal GUI mode ----
   Valeronoi::ValeronoiWindow valeronoi;
   if (!parser.positionalArguments().isEmpty()) {
     if (!valeronoi.load_file(parser.positionalArguments().value(0))) {

--- a/src/robot/api/valetudo_v2.cpp
+++ b/src/robot/api/valetudo_v2.cpp
@@ -250,4 +250,19 @@ void ValetudoAPI::relocate(int x, int y) {
           false, true, &data);
 }
 
+void ValetudoAPI::set_operation_mode(const QString& mode) {
+  if (!m_connected) {
+    return;
+  }
+  auto document = QJsonDocument();
+  auto object = QJsonObject();
+  object.insert("name", mode);
+  document.setObject(object);
+  auto data = document.toJson();
+  request(
+      "PUT",
+      QUrl("/api/v2/robot/capabilities/OperationModeControlCapability/preset"),
+      false, true, &data);
+}
+
 }  // namespace Valeronoi::robot::api::v2

--- a/src/robot/api/valetudo_v2.h
+++ b/src/robot/api/valetudo_v2.h
@@ -62,6 +62,8 @@ class ValetudoAPI : public QObject {
 
   void send_command(Valeronoi::robot::BASIC_COMMANDS command);
 
+  void set_operation_mode(const QString& mode);
+
   void relocate(int x, int y);
 
  public slots:

--- a/src/robot/robot.cpp
+++ b/src/robot/robot.cpp
@@ -117,6 +117,10 @@ void Robot::send_command(BASIC_COMMANDS command) {
   m_api.send_command(command);
 }
 
+void Robot::set_operation_mode(const QString& mode) {
+  m_api.set_operation_mode(mode);
+}
+
 void Robot::slot_relocate(int x, int y) { m_api.relocate(x, y); }
 
 }  // namespace Valeronoi::robot

--- a/src/robot/robot.h
+++ b/src/robot/robot.h
@@ -52,6 +52,8 @@ class Robot : public QObject {
 
   void send_command(BASIC_COMMANDS command);
 
+  void set_operation_mode(const QString& mode);
+
  public slots:
   void slot_connect();
 


### PR DESCRIPTION
### Motivation

Running Valeronoi on a headless home server enables fully automated, scheduled WiFi scans (e.g. via cron or systemd timers). Previously, the application required a display and manual interaction through the GUI to start recordings.

### Added / Changes

**New: Headless CLI recorder** (`src/cli/headless_recorder.{h,cpp}`)
- Connects to the robot, sets operation mode, sends commands, and records WiFi measurements (all without GUI).
- Graceful shutdown on `Ctrl+C` / `SIGTERM`: saves collected data before exiting.
- Non-start commands (`stop`, `home`, `pause`, `locate`) execute immediately and exit.

**Modified: `src/main.cpp`**
- Added CLI options: `--headless`, `--url`, `--output`, `--duration`, `--interval`, `--mode`, `--command`, `--auth`, `--user`, `--pass`.
- Sets `QT_QPA_PLATFORM=offscreen` when `--headless` is detected (before `QApplication` is created).

**Modified: Robot API layer**
- `Robot::set_operation_mode()` and `ValetudoAPI::set_operation_mode()` added to support setting the operation mode (e.g. `vacuum`) via `PUT /api/v2/robot/capabilities/OperationModeControlCapability/preset`.

**New: Containerfiles**
- `Containerfile.build`: Build environment (Ubuntu 22.04, Qt6, CGAL).
- `Containerfile.run`: Minimal runtime image with `QT_QPA_PLATFORM=offscreen`.

**Updated: `README.md`**
- New "Headless CLI Mode" section with usage examples, options table, container instructions, and cron example.

### Usage examples

```bash

### Record for 30 minutes in vacuum-only mode

valeronoi --headless --url http://192.168.1.100 \
  --mode vacuum --command start --output scan.vwm --duration 1800

### Send robot home (no recording)

valeronoi --headless --url http://192.168.1.100 --command home

### Container

podman run --rm --network host -v ./out:/output:Z valeronoi \
  --headless --url http://192.168.1.100 \
  --mode vacuum --command start \
  --output /output/scan.vwm --duration 1800